### PR TITLE
Fix tree-view re-rendering 

### DIFF
--- a/lib/reps/tree-view.js
+++ b/lib/reps/tree-view.js
@@ -62,6 +62,11 @@ var TreeView = React.createFactory(React.createClass({
     this.setState({data: members, searchFilter: this.props.searchFilter});
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    var members = this.initMembers(nextProps.data, 0);
+    this.setState({data: members, searchFilter: nextProps.searchFilter});
+  },
+
   initMembers: function(parent, level) {
     var members = this.getMembers(parent, level);
     for (var i in members) {


### PR DESCRIPTION
If a React component is already mounted and its props change during a re-rendering,
we have to define a React `componentWillReceiveProps` lifecycle handler to regenerate
the tree-view members list from the new props.
