### PR TITLE
fix React warning "Don't set .props.delim of the React component <PropRep />."

### DIFF
--- a/lib/reps/object.js
+++ b/lib/reps/object.js
@@ -91,8 +91,10 @@ const Obj = React.createClass({
     }
     else if (props.length > 0) {
       // Remove the last comma.
-      // xxxHonza: is it ok to access the '_store' object?
-      props[props.length-1]._store.props.delim = "";
+
+      // NOTE: do not change comp._store.props directly to update a property,
+      // it should be re-rendered or cloned with changed props
+      props[props.length-1] = React.cloneElement(props[props.length-1], { delim: "" });
     }
 
     return props;


### PR DESCRIPTION
This PR introduces a small fix to the React warning: "Don't set .props.delim of the React component <PropRep />."

To prevent the warning we have to clone the React elements with the changed properties instead of changing the properties already stored in the component and managed by React.
