### PR TITLE
optionally mark sent packet as rdpInspectorInternals

### DIFF
--- a/lib/core/rdp.js
+++ b/lib/core/rdp.js
@@ -9,6 +9,7 @@ module.metadata = {
 const { defer, all, resolve } = require("sdk/core/promise");
 const { Trace, TraceError } = require("./trace.js").get(module.id);
 const { System } = require("./system.js");
+let { merge } = require("sdk/util/object");
 
 // xxxHonza: Firefox 36+
 const { ActorRegistryFront } = System.devtoolsRequire("devtools/server/actors/actor-registry");
@@ -42,7 +43,18 @@ Rdp.registerGlobalActor = function(client, options) {
     return;
   }
 
-  client.listTabs(response => {
+  let listTabs = {
+    to: "root",
+    type: "listTabs"
+  };
+
+  // NOTE: the following option asks firebug.sdk to merge custom attributes in the RDP packets
+  // (e.g. to mark them for tracking)
+  if (options.customAttributes) {
+    listTabs = merge(options.customAttributes, listTabs)
+  }
+
+  client.request(listTabs,response => {
     // Just attach if already registered.
     if (response[typeName]) {
       Rdp.attachActor(client, frontCtor, response).then(front => {
@@ -68,7 +80,7 @@ Rdp.registerGlobalActor = function(client, options) {
       Trace.sysout("rdp.registerGlobalActor; registration done: " +
         typeName, registrar);
 
-      client.listTabs(response => {
+      client.request(listTabs, response => {
         Rdp.attachActor(client, frontCtor, response).then(front => {
           Trace.sysout("rdp.registerGlobalActor; attach done: " +
             typeName, front);
@@ -103,7 +115,18 @@ Rdp.registerTabActor = function(client, options) {
     return;
   }
 
-  client.listTabs(response => {
+  let listTabs = {
+    to: "root",
+    type: "listTabs"
+  };
+
+  // NOTE: the following option asks firebug.sdk to merge custom attributes in the RDP packets
+  // (e.g. to mark them for tracking)
+  if (options.customAttributes) {
+    listTabs = merge(options.customAttributes, listTabs)
+  }
+
+  client.request(listTabs, response => {
     // Just attach if already registered.
     let tabForm = response.tabs[response.selected];
     if (tabForm[typeName]) {
@@ -130,7 +153,7 @@ Rdp.registerTabActor = function(client, options) {
       Trace.sysout("rdp.registerTabActor; registration done: " +
         typeName, registrar);
 
-      client.listTabs(response => {
+      client.request(listTabs, response => {
         let form = response.tabs[response.selected];
         Rdp.attachActor(client, frontCtor, form).then(front => {
           Trace.sysout("rdp.registerTabActor; attach done: " +
@@ -301,4 +324,3 @@ Rdp.getLongString = function(stringGrip, webConsoleClient) {
 
 // Exports from this module
 exports.Rdp = Rdp;
-


### PR DESCRIPTION
Changes needed by RDP Inspector to be able to filter out RDP packets needed by the tools itself (firebug/rdp-inspector#55), by optionally mark RDP packets used to register custom global / tab actors as `rdpInspectorInternals`.  
