### PR TITLE
fix util.merge exception

### DIFF
--- a/lib/core/rdp.js
+++ b/lib/core/rdp.js
@@ -51,7 +51,7 @@ Rdp.registerGlobalActor = function(client, options) {
   // NOTE: the following option asks firebug.sdk to merge custom attributes in the RDP packets
   // (e.g. to mark them for tracking)
   if (options.customAttributes) {
-    listTabs = merge(options.customAttributes, listTabs)
+    listTabs = merge({}, options.customAttributes, listTabs);
   }
 
   client.request(listTabs,response => {
@@ -123,7 +123,7 @@ Rdp.registerTabActor = function(client, options) {
   // NOTE: the following option asks firebug.sdk to merge custom attributes in the RDP packets
   // (e.g. to mark them for tracking)
   if (options.customAttributes) {
-    listTabs = merge(options.customAttributes, listTabs)
+    listTabs = merge({}, options.customAttributes, listTabs);
   }
 
   client.request(listTabs, response => {


### PR DESCRIPTION
This PR fix an exception raised on merging the options.customAttributes with the fixed listTabs object.
