### PR TITLE
Fix devtools imports in preparation to Bug 912121

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -6,14 +6,13 @@ module.metadata = {
   "stability": "experimental"
 };
 
-const { Cu, Ci } = require("chrome");
 const { Trace, TraceError } = require("./core/trace.js").get(module.id);
 const { EventTarget } = require("sdk/event/target");
 const { Class } = require("sdk/core/heritage");
 const { Win } = require("./core/window.js");
 
 // DevTools
-const { gDevTools } = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
+const { gDevTools } = require("./core/devtools");
 
 /**
  * This object represents a toolbox context that shares the same

--- a/lib/core/devtools.js
+++ b/lib/core/devtools.js
@@ -1,0 +1,18 @@
+/* See license.txt for terms of usage */
+
+"use strict";
+
+const { Cu } = require("chrome");
+
+try {
+  // new devtools modules path (https://github.com/jryans/devtools-migrate/blob/master/README.md)
+  exports.devtools = Cu.import("resource://gre/modules/devtools/shared/Loader.jsm", {});
+  exports.makeInfallible = exports.devtools["require"]("devtools/shared/DevToolsUtils.js");
+  exports.gDevTools = Cu.import("resource:///modules/devtools/client/framework/gDevTools.jsm")
+
+} catch(e) {
+  // old devtools modules path
+  exports.devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+  exports.makeInfallible = exports.devtools["require"]("devtools/toolkit/DevToolsUtils.js");
+  exports.gDevTools = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
+}

--- a/lib/core/system.js
+++ b/lib/core/system.js
@@ -2,10 +2,11 @@
 
 "use strict";
 
-const { Cu, Ci } = require("chrome");
+const { Cu } = require("chrome");
 const { getMostRecentBrowserWindow } = require("sdk/window/utils");
 
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+const { devtools } = require("./devtools");
+
 const { Services } = Cu.import("resource://gre/modules/Services.jsm", {});
 
 const currentBrowserVersion = Services.appinfo.platformVersion;
@@ -17,7 +18,7 @@ let System = {};
  *
  * @param version string to compare with.
  * @returns {Integer} Possible result values:
- * is smaller than 0, the current version < version 
+ * is smaller than 0, the current version < version
  * equals 0 then the current version == version
  * is bigger than 0, then the current version > version
  */

--- a/lib/core/window.js
+++ b/lib/core/window.js
@@ -2,15 +2,13 @@
 
 "use strict";
 
-const { Cu } = require("chrome");
-
 const { Trace, TraceError } = require("../core/trace.js").get(module.id);
 const { once } = require("sdk/dom/events.js");
 const { getMostRecentBrowserWindow } = require("sdk/window/utils");
 const { openTab } = require("sdk/tabs/utils");
 
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
-const { makeInfallible } = devtools["require"]("devtools/toolkit/DevToolsUtils.js");
+// DevTools
+const { makeInfallible } = require("./devtools");
 
 // Module implementation
 var Win = {};

--- a/lib/toolbox-chrome.js
+++ b/lib/toolbox-chrome.js
@@ -18,7 +18,7 @@ const { Context } = require("./context.js");
 const { Dispatcher } = require("./dispatcher.js");
 
 // DevTools
-const { gDevTools } = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
+const { gDevTools } = require("./core/devtools");
 
 /**
  * TODO docs


### PR DESCRIPTION
This PR is related to firebug/rdp-inspector#68 and introduce the new imports urls as described in https://github.com/jryans/devtools-migrate/blob/master/README.md

The idea is to concentrate all the imports in a new `firebug.sdk/core/devtools` module and use it to import the required components (and be retrocompatible to the previous paths)   

It's still untested but I'm opening it just to keep track of it.

I need to build a recent version of firefox from mozilla-central and fix the remaining imports in the rdp-inspector itself to be able to fully test it.

TODO:
- [ ] test the patch on a recent mozilla-central build
