### PR TITLE
emit the applied toolbox overlays to the dispatcher

### DIFF
--- a/lib/toolbox-chrome.js
+++ b/lib/toolbox-chrome.js
@@ -231,6 +231,8 @@ var ToolboxChrome = extend(EventTarget.prototype,
 
         context.overlays.set(overlayId, instance);
 
+        Dispatcher.emit("onToolboxOverlay", [{ overlay: instance, toolbox }])
+
         // Execute 'onReady' on the overlay instance when the toolbox
         // is ready. There are two options, (a) the toolbox is already
         // ready at this point (extension installed dynamically in the


### PR DESCRIPTION
This small change is related to firebug/rdp-inspector#67

it just emits to the FBSDK's Dispatcher the overlay created (so it can be collected from the InspectorService and associated to the monitored RDP connection, and then it can be used to open an RDP Inspector window on a defined connection or toolbox.
