### PR TITLE
prepare to support new devtools resource urls with fallbacks

### DIFF
--- a/lib/core/devtools.js
+++ b/lib/core/devtools.js
@@ -4,27 +4,26 @@
 
 const { Cu } = require("chrome");
 
-// Support for new devtools modules path.
-// See also:
-// * https://wiki.mozilla.org/DevTools/Hacking
-// * https://github.com/jryans/devtools-migrate/blob/master/README.md
-// * https://developer.mozilla.org/en-US/docs/Tools/Contributing
-// * https://bugzilla.mozilla.org/show_bug.cgi?id=912121
-try {
-  exports.devtools = Cu.import("resource://gre/modules/devtools/shared/Loader.jsm", {}).devtools;
-  exports.DevToolsUtils = exports.devtools["require"]("devtools/shared/DevToolsUtils");
-  exports.makeInfallible = exports.DevToolsUtils.makeInfallible;
-  exports.gDevTools = Cu.import("resource:///modules/devtools/client/framework/gDevTools.jsm").gDevTools;
-  exports.EventEmitter = exports.devtools["require"]("devtools/shared/event-emitter");
-  exports.ToolSidebar = exports.devtools["require"]("devtools/client/framework/sidebar").ToolSidebar;
-} catch(e) {
-  exports.devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
-  exports.DevToolsUtils = exports.devtools["require"]("devtools/toolkit/DevToolsUtils");
-  exports.makeInfallible = exports.DevToolsUtils.makeInfallible;
-  exports.gDevTools = Cu.import("resource:///modules/devtools/gDevTools.jsm", {}).gDevTools;
-  exports.EventEmitter = exports.devtools["require"]("devtools/toolkit/event-emitter");
-  exports.ToolSidebar = exports.devtools["require"]("devtools/framework/sidebar").ToolSidebar;
+/**
+ * Allows importing a JS module (Firefox platform) and specify alternative locations
+ * to keep backward compatibility in case when the module location changes.
+ * It helps Firebug to support multiple Firefox versions.
+ *
+ * @param {Array} locations List of URLs to try when importing the module.
+ * @returns Scope of the imported module or an empty scope if module wasn't successfully loaded.
+ */
+function safeImport(...args) {
+  for (var i=0; i<args.length; i++) {
+    try {
+      return Cu["import"](args[i], {});
+    }
+    catch (err) {
+    }
+  }
+  return {};
 }
+
+exports.safeImport = safeImport;
 
 /**
  * Allows requiring a devtools module and specify alternative locations
@@ -35,7 +34,7 @@ try {
  * @param {Array} locations List of URLs to try when importing the module.
  * @returns Scope of the imported module or an empty scope if module wasn't successfully loaded.
  */
-exports.safeRequire = function(devtools, ...args) {
+function safeRequire(devtools, ...args) {
   for (var i=0; i<args.length; i++) {
     try {
       return devtools["require"](args[i]);
@@ -44,23 +43,43 @@ exports.safeRequire = function(devtools, ...args) {
     }
   }
   return {};
-};
+}
 
-/**
- * Allows importing a JS module (Firefox platform) and specify alternative locations
- * to keep backward compatibility in case when the module location changes.
- * It helps Firebug to support multiple Firefox versions.
- *
- * @param {Array} locations List of URLs to try when importing the module.
- * @returns Scope of the imported module or an empty scope if module wasn't successfully loaded.
- */
-exports.safeImport = function(...args) {
-  for (var i=0; i<args.length; i++) {
-    try {
-      return Cu["import"](args[i], {});
-    }
-    catch (err) {
-    }
-  }
-  return {};
-};
+exports.safeRequire = safeRequire;
+
+// Support for new devtools modules path.
+// See also:
+// * https://wiki.mozilla.org/DevTools/Hacking
+// * https://github.com/jryans/devtools-migrate/blob/master/README.md
+// * https://developer.mozilla.org/en-US/docs/Tools/Contributing
+// * https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+// * https://bugzilla.mozilla.org/show_bug.cgi?id=1203159
+
+const devtools = exports.devtools = safeImport(
+  "resource://devtools/shared/Loader.jsm",
+  "resource://gre/modules/devtools/shared/Loader.jsm",
+  "resource://gre/modules/devtools/Loader.jsm"
+).devtools;
+
+exports.DevToolsUtils = safeRequire(devtools,
+  "devtools/shared/DevToolsUtils",
+  "devtools/toolkit/DevToolsUtils"
+);
+
+exports.makeInfallible = exports.DevToolsUtils.makeInfallible;
+
+exports.gDevTools = safeImport(
+  "resource:///devtools/client/framework/gDevTools.jsm",
+  "resource:///modules/devtools/client/framework/gDevTools.jsm",
+  "resource:///modules/devtools/gDevTools.jsm"
+).gDevTools;
+
+exports.EventEmitter = safeRequire(devtools,
+  "devtools/shared/event-emitter",
+  "devtools/toolkit/event-emitter"
+);
+
+exports.ToolSidebar = safeRequire(devtools,
+  "devtools/client/framework/sidebar",
+  "devtools/framework/sidebar"
+);


### PR DESCRIPTION
This PR uses the safeImport helper to add the new devtools resource urls (introduced by https://bugzilla.mozilla.org/show_bug.cgi?id=1203159) to the supported fallback urls.
