### PR TITLE
Render links in TreeView as <a> tags

### DIFF
--- a/lib/reps/tree-view.js
+++ b/lib/reps/tree-view.js
@@ -6,7 +6,7 @@ define(function(require, exports, module) {
 const React = require("react");
 const { Reps } = require("reps/repository");
 const { isCropped } = require("reps/string");
-const { TR, TD, SPAN, TABLE, TBODY } = Reps.DOM;
+const { A, TR, TD, SPAN, TABLE, TBODY } = Reps.DOM;
 
 /**
  * @template This component represents a tree view with
@@ -328,6 +328,11 @@ var TreeRow = React.createFactory(React.createClass({
       TAG = Reps.getRep(value);
     }
 
+    var isLink = false;
+    if (typeof value === 'string' && /^https?:\/\/.+$/.test(value)) {
+      isLink = true;
+    }
+
     return (
       TR({className: classNames.join(" "), onClick: this.onClick},
         TD({className: "memberLabelCell", style: rowStyle},
@@ -335,7 +340,13 @@ var TreeRow = React.createFactory(React.createClass({
             name)
         ),
         TD({className: "memberValueCell"},
-          SPAN({},
+          // If the value is a link, render as an A tag that opens
+          // in a new window
+          (isLink ? A : SPAN)(
+            isLink ? {
+              href: value,
+              target: '_blank'
+            } : {},
             TAG({
               object: value,
               mode: this.props.mode,


### PR DESCRIPTION
This PR adresses https://github.com/firebug/websocket-monitor/issues/51

This is my first take, thought I'd get some feedback. This is the simplest possible solution - it uses an `<a>` with href that opens in a new window. I thought this might open in a new tab if the user has configured their browser to do so, but that seems to not be the case. It seems to always open in a new window.

These links render like any other text, with the exception that they get a hand when you hover over them. 
