### PR TITLE
Issue #19 - Reps: falsy value shouldn't default to empty string

### DIFF
--- a/lib/reps/tree-view.js
+++ b/lib/reps/tree-view.js
@@ -293,7 +293,7 @@ var TreeRow = React.createFactory(React.createClass({
 
     var filter = this.props.searchFilter;
     var name = member.name || "";
-    var value = member.value || "";
+    var value = member.value;
 
     var provider = this.props.provider;
     if (provider) {


### PR DESCRIPTION
If the value is falsy, don't replace it with empty string.